### PR TITLE
Properly fetch the article file path relative to git directory's parent

### DIFF
--- a/lib/jekyll-last-modified-at.rb
+++ b/lib/jekyll-last-modified-at.rb
@@ -19,7 +19,7 @@ module Jekyll
         Dir.chdir(site_source) do
           top_level_git_directory = File.join(`git rev-parse --show-toplevel`.strip, ".git")
         end
-        relative_file_path = File.expand_path(article_file_path, top_level_git_directory)
+        relative_file_path = Pathname.new(article_file_path).relative_path_from(Pathname.new(File.dirname(top_level_git_directory))).to_s
         last_commit_date = IO.popen(['git', '--git-dir', top_level_git_directory, 'log', '--format="%ct"', '--', relative_file_path]).read[/\d+/]
         # last_commit_date can be nil iff the file was not committed.
         last_modified_time = (last_commit_date.nil? || last_commit_date.empty?) ? mtime(article_file_path) : last_commit_date


### PR DESCRIPTION
As I was running v0.2.0 on my personal site, I kept getting this (debug message mine):

``` text
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- /tmp/parkermoore.de/portfolio.html
fatal: /tmp/parkermoore.de/portfolio.html: '/tmp/parkermoore.de/portfolio.html' is outside repository
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- /tmp/parkermoore.de/404.md
fatal: /tmp/parkermoore.de/404.md: '/tmp/parkermoore.de/404.md' is outside repository
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- /tmp/parkermoore.de/projects.md
fatal: /tmp/parkermoore.de/projects.md: '/tmp/parkermoore.de/projects.md' is outside repository
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- /tmp/parkermoore.de/resume.md
fatal: /tmp/parkermoore.de/resume.md: '/tmp/parkermoore.de/resume.md' is outside repository
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- /tmp/parkermoore.de/index.md
fatal: /tmp/parkermoore.de/index.md: '/tmp/parkermoore.de/index.md' is outside repository
```

Turns out the filename after the `--` has to be the relative path from the git directory's parent. With the attached changes, I successfully achieved the output I was looking for:

``` text
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- portfolio.html
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- 404.md
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- projects.md
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- resume.md
git --git-dir /tmp/parkermoore.de/.git log --format="%ct" -- index.md
```

No error messages, yay!
