### PR TITLE
Suppress git error output when site isn't under source control.

### DIFF
--- a/lib/jekyll-last-modified-at.rb
+++ b/lib/jekyll-last-modified-at.rb
@@ -32,7 +32,7 @@ module Jekyll
 
     def is_git_repo?(site_source)
       Dir.chdir(site_source) do
-        `git rev-parse --is-inside-work-tree`.strip == "true"
+        `git rev-parse --is-inside-work-tree 2> /dev/null`.strip == "true"
       end
     rescue
       false


### PR DESCRIPTION
Hi gjtorikian, Nice plugin. Here's a patch for us poor souls laboring outside of GIT repos. - chuckhoupt
#### Details:

When working in a directory that isn't part of a GIT repo, the plugin generates the following error message for each file processed:

```
fatal: Not a git repository (or any of the parent directories): .git
```

This patch fixes this by dev-nulling the output from the 'git rev-parse' command in is_git_repo?()
