### PR TITLE
When passing Determinator to Liquid, give a Time.

### DIFF
--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -9,15 +9,19 @@ module Jekyll
         @opts        = opts
       end
 
-      def last_modified_at_date
+      def formatted_last_modified_date
+        last_modified_at_time.strftime(format)
+      end
+
+      def last_modified_at_time
         unless File.exists? absolute_path_to_article
           raise Errno::ENOENT, "#{absolute_path_to_article} does not exist!"
         end
 
-        Time.at(last_modified_time.to_i).strftime(format)
+        Time.at(last_modified_at_unix.to_i)
       end
 
-      def last_modified_time
+      def last_modified_at_unix
         if is_git_repo?(site_source)
           last_commit_date = Executor.sh(
             'git',
@@ -34,11 +38,14 @@ module Jekyll
           mtime(absolute_path_to_article)
         end
       end
-      
+
       def to_s
-        @to_s ||= last_modified_at_date
+        @to_s ||= formatted_last_modified_date
       end
-      alias_method :to_liquid, :to_s
+
+      def to_liquid
+        @to_liquid ||= last_modified_at_time
+      end
 
       def format
         opts['format'] ||= "%d-%b-%y"

--- a/lib/jekyll-last-modified-at/tag.rb
+++ b/lib/jekyll-last-modified-at/tag.rb
@@ -12,7 +12,7 @@ module Jekyll
 
         Determinator.new(site_source, article_file, {
           "format" => @format
-        }).last_modified_at_date
+        }).formatted_last_modified_date
       end
     end
   end

--- a/spec/jekyll-last-modified-at/determinator_spec.rb
+++ b/spec/jekyll-last-modified-at/determinator_spec.rb
@@ -3,14 +3,19 @@ require "spec_helper"
 describe(Jekyll::LastModifiedAt::Determinator) do
   let(:site_source) { @fixtures_path }
   let(:page_path)   { @fixtures_path.join("_posts").join("1984-03-06-command.md|whoami>.bogus") }
+  let(:mod_time)    { Time.new(2014, 01, 15, 13, 00, 44, "-08:00") }
   subject { described_class.new(site_source.to_s, page_path.to_s) }
 
   it "knows the last modified date of the file in question" do
-    expect(subject.last_modified_at_date).to eql("15-Jan-14")
+    expect(subject.formatted_last_modified_date).to eql("15-Jan-14")
+  end
+
+  it "knows the last modified time (as a time object) of the file" do
+    expect(subject.last_modified_at_time).to eql(mod_time)
   end
 
   it "knows the last modified time of the file in question" do
-    expect(subject.last_modified_time).to eql("1389819644")
+    expect(subject.last_modified_at_unix).to eql("1389819644")
   end
 
   context "not in a git repo" do
@@ -18,16 +23,32 @@ describe(Jekyll::LastModifiedAt::Determinator) do
     let(:page_path)   { site_source.join("some_file.txt") }
     let(:mod_time)    { Time.now }
     before(:each) do
-      File.stub!(:mtime).and_return(mod_time)
-      File.stub!(:exists?).and_return(true)
+      File.stub(:mtime).and_return(mod_time)
+      File.stub(:exists?).and_return(true)
     end
 
     it "uses the write time" do
-      expect(subject.last_modified_time).to eql(mod_time)
+      expect(subject.last_modified_at_time.to_i).to eql(mod_time.to_i)
     end
 
     it "uses the write time for the date, too" do
-      expect(subject.last_modified_at_date).to eql(mod_time.strftime("%d-%b-%y"))
+      expect(subject.formatted_last_modified_date).to eql(mod_time.strftime("%d-%b-%y"))
+    end
+  end
+
+  context "#to_s" do
+    it "returns the formatted date" do
+      expect(subject.to_s).to eql("15-Jan-14")
+    end
+  end
+
+  context "#to_liquid" do
+    it "returns a Time object" do
+      expect(subject.to_liquid).to be_a(Time)
+    end
+
+    it "returns the correct time" do
+      expect(subject.to_liquid).to eql(mod_time)
     end
   end
 

--- a/spec/jekyll-last-modified-at/generator_spec.rb
+++ b/spec/jekyll-last-modified-at/generator_spec.rb
@@ -16,6 +16,6 @@ describe(Jekyll::LastModifiedAt::Generator) do
   end
 
   it "fetches the last modified date if transformed to liquid" do
-    expect(subject.to_liquid).to be_a(String)
+    expect(subject.to_liquid).to be_a(Time)
   end
 end


### PR DESCRIPTION
This means the formatting does _not_ happen in `#to_liquid`.

Fixes #25 
