### PR TITLE
Bump Jekyll dependency

### DIFF
--- a/jekyll-last-modified-at.gemspec
+++ b/jekyll-last-modified-at.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license               = "MIT"
   s.files                 = Dir["lib/**/*.rb"]
 
-  s.add_dependency "jekyll", "~> 3.2.1"
+  s.add_dependency "jekyll", "~> 3.3.0"
   s.add_dependency "posix-spawn", "~> 0.3.9"
 
   s.add_development_dependency "rspec", "~> 2.13.0"


### PR DESCRIPTION
[This PR](https://github.com/gjtorikian/jekyll-last-modified-at/pull/40) is a little outdated since Jekyll 3.3.0 is released, bump dependency to support latest Jekyll.