### PR TITLE
.travis.yml update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,3 @@ rvm:
 
 sudo: false
 cache: bundler
-
-script: "./script/cibuild"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.3.3
+  - 2.4
+  - 2.5
 
 sudo: false
 cache: bundler

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,6 @@ RSpec.configure do |config|
     @dest = @fixtures_path.join("_site")
     @posts_src = File.join(@fixtures_path, "_posts")
     @layouts_src = File.join(@fixtures_path, "_layouts")
-    @plugins_src = File.join(@fixtures_path, "_plugins")
 
     $stderr = File.new(File.join(File.dirname(__FILE__), 'dev', 'err.txt'), 'w')
     $stdout = File.new(File.join(File.dirname(__FILE__), 'dev', 'out.txt'), 'w')
@@ -40,7 +39,6 @@ RSpec.configure do |config|
     @site = Jekyll::Site.new(Jekyll.configuration({
       "source"      => @fixtures_path.to_s,
       "destination" => @dest.to_s,
-      "plugins"     => @plugins_src
     }))
 
     @dest.rmtree if @dest.exist?


### PR DESCRIPTION
The `script/cibuild` has no benefit on travis, as bundler install has already been run, and the default ruby script does the same thing.

Also add more recent ruby versions.