### PR TITLE
determinator.rb: Check is git repo only once

### DIFF
--- a/lib/jekyll-last-modified-at.rb
+++ b/lib/jekyll-last-modified-at.rb
@@ -6,9 +6,12 @@ module Jekyll
     autoload :Determinator, 'jekyll-last-modified-at/determinator'
     autoload :Tag, 'jekyll-last-modified-at/tag'
     autoload :Hook, 'jekyll-last-modified-at/hook'
+    autoload :Git, 'jekyll-last-modified-at/git'
 
     Tag ; Hook
 
     PATH_CACHE = {}
+
+    REPO_CACHE = {}
   end
 end

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -7,7 +7,12 @@ module Jekyll
         @site_source = site_source
         @page_path   = page_path
         @opts        = opts
-        @is_git_repo = nil
+      end
+
+      def git
+        return REPO_CACHE[site_source] unless REPO_CACHE[site_source].nil?
+        REPO_CACHE[site_source] = Git.new(site_source)
+        REPO_CACHE[site_source]
       end
 
       def formatted_last_modified_date
@@ -26,11 +31,11 @@ module Jekyll
       end
 
       def last_modified_at_unix
-        if is_git_repo?(site_source)
+        if git.is_git_repo?
           last_commit_date = Executor.sh(
             'git',
             '--git-dir',
-            top_level_git_directory,
+            git.top_level_directory,
             'log',
             '--format="%ct"',
             '--',
@@ -66,32 +71,11 @@ module Jekyll
       end
 
       def relative_path_from_git_dir
-        return nil unless is_git_repo?(site_source)
+        return nil unless git.is_git_repo?
         @relative_path_from_git_dir ||= Pathname.new(absolute_path_to_article)
           .relative_path_from(
-            Pathname.new(File.dirname(top_level_git_directory))
+            Pathname.new(File.dirname(git.top_level_directory))
           ).to_s
-      end
-
-      def top_level_git_directory
-        @top_level_git_directory ||= begin
-          Dir.chdir(site_source) do
-            top_level_git_directory = File.join(Executor.sh("git", "rev-parse", "--show-toplevel"), ".git")
-          end
-        rescue
-          ""
-        end
-      end
-
-      def is_git_repo?(site_source)
-        return @is_git_repo unless @is_git_repo.nil?
-        @is_git_repo = begin
-          Dir.chdir(site_source) do
-            Executor.sh("git", "rev-parse", "--is-inside-work-tree").eql? "true"
-          end
-        rescue
-          false
-        end
       end
 
       def mtime(file)

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -7,6 +7,7 @@ module Jekyll
         @site_source = site_source
         @page_path   = page_path
         @opts        = opts
+        @is_git_repo = nil
       end
 
       def formatted_last_modified_date
@@ -83,7 +84,8 @@ module Jekyll
       end
 
       def is_git_repo?(site_source)
-        @is_git_repo ||= begin
+        return @is_git_repo unless @is_git_repo.nil?
+        @is_git_repo = begin
           Dir.chdir(site_source) do
             Executor.sh("git", "rev-parse", "--is-inside-work-tree").eql? "true"
           end

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -1,0 +1,35 @@
+module Jekyll
+  module LastModifiedAt
+    class Git
+      attr_reader :site_source
+
+      def initialize(site_source)
+        @site_source = site_source
+        @is_git_repo = nil
+      end
+
+      def top_level_directory
+        return nil unless is_git_repo?
+        @top_level_directory ||= begin
+          Dir.chdir(@site_source) do
+            top_level_directory = File.join(Executor.sh("git", "rev-parse", "--show-toplevel"), ".git")
+          end
+        rescue
+          ""
+        end
+      end
+
+      def is_git_repo?
+        return @is_git_repo unless @is_git_repo.nil?
+        @is_git_repo = begin
+          Dir.chdir(@site_source) do
+            Executor.sh("git", "rev-parse", "--is-inside-work-tree").eql? "true"
+          end
+        rescue
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/spec/jekyll-last-modified-at/determinator_spec.rb
+++ b/spec/jekyll-last-modified-at/determinator_spec.rb
@@ -6,6 +6,12 @@ describe(Jekyll::LastModifiedAt::Determinator) do
   let(:mod_time)    { Time.new(2014, 01, 15, 13, 00, 44, "-08:00") }
   subject { described_class.new(site_source.to_s, page_path.to_s) }
 
+  it "determines it is a git repo" do
+    expect(subject.git.is_git_repo?).to eql(true)
+    expect(subject.git.site_source).to end_with('spec/fixtures')
+    expect(subject.git.top_level_directory).to end_with('/.git')
+  end
+
   it "knows the last modified date of the file in question" do
     expect(subject.formatted_last_modified_date).to eql("15-Jan-14")
   end
@@ -25,6 +31,12 @@ describe(Jekyll::LastModifiedAt::Determinator) do
     before(:each) do
       File.stub(:mtime).and_return(mod_time)
       File.stub(:exists?).and_return(true)
+    end
+
+    it "determines it is not a git repo" do
+      expect(subject.git.is_git_repo?).to eql(false)
+      expect(subject.git.site_source).to eql('/tmp')
+      expect(subject.git.top_level_directory).to eql(nil)
     end
 
     it "uses the write time" do


### PR DESCRIPTION
When there is no git repository, `is_git_repo?` was false,
and the `||=` checks for a git repository every invocation.

Fixes https://github.com/gjtorikian/jekyll-last-modified-at/issues/60