### PR TITLE
Allow Jekyll > 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ _site/
 Gemfile.lock
 spec/fixtures/_posts/1992-09-11-last-modified-at.md
 spec/fixtures/.jekyll-metadata
+spec/fixtures/.jekyll-cache
 spec/dev/out.txt
 spec/dev/err.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
-rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.1
-
-sudo: false
 cache: bundler
 
-script: "./script/cibuild"
+rvm:
+  - 2.6
+  - 2.4
+  
+script: script/cibuild

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-last-modified-at.gemspec
+++ b/jekyll-last-modified-at.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license               = "MIT"
   s.files                 = Dir["lib/**/*.rb"]
 
-  s.add_dependency "jekyll", "> 3.7", " < 5.0"
+  s.add_dependency "jekyll", ">= 3.7", " < 5.0"
   s.add_dependency "posix-spawn", "~> 0.3.9"
 
   s.add_development_dependency "rspec", "~> 3.4"

--- a/jekyll-last-modified-at.gemspec
+++ b/jekyll-last-modified-at.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license               = "MIT"
   s.files                 = Dir["lib/**/*.rb"]
 
-  s.add_dependency "jekyll", "~> 3.3"
+  s.add_dependency "jekyll", "> 3.7", " < 5.0"
   s.add_dependency "posix-spawn", "~> 0.3.9"
 
   s.add_development_dependency "rspec", "~> 3.4"

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,2 +1,1 @@
 name: Your New Jekyll Site
-markdown: redcarpet

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,6 @@ RSpec.configure do |config|
     @site = Jekyll::Site.new(Jekyll.configuration({
       "source"      => @fixtures_path.to_s,
       "destination" => @dest.to_s,
-      "plugins"     => @plugins_src
     }))
 
     @dest.rmtree if @dest.exist?


### PR DESCRIPTION
👋 Hi @gjtorikian 

@jekyll/core team bumped `jekyll` version constraint in `jekyll-sitemap`:

```
spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
spec.add_development_dependency "jekyll-last-modified-at", "~> 1.0"
```

As a result running `bundle update` will throw a dependency error:

``` 
In Gemfile:
    jekyll-last-modified-at (~> 1.0) was resolved to 1.0.0, which depends on
      jekyll (~> 3.2.1)

    jekyll-sitemap was resolved to 1.3.2, which depends on
      jekyll (>= 3.7, < 5.0)
```

This patch aims to match version constaint on Jekyll, to allow test first v4 alpha.

We're also dropping support for Ruby < 2.4 as 2.3 goes EOL at the end of the month.

Thanks.