### PR TITLE
Perf: only log latest commit

### DIFF
--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -31,6 +31,8 @@ module Jekyll
             '--git-dir',
             top_level_git_directory,
             'log',
+            '-n',
+            '1',
             '--format="%ct"',
             '--',
             relative_path_from_git_dir


### PR DESCRIPTION
This limits the output of `git log` to only show 1 commit instead of the entire history of commits. In my unscientific testing, this resulted in a 33% performance increase on a very large site (10,000+ pages)