### PR TITLE
Added configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ plugins:
   - jekyll-last-modified-at
 
 # Optional. The default date format, used if none is specified in the tag.
-date_format: '%d-%b-%y'
+last-modified-at:
+    date-format: '%d-%b-%y'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Add the following to your site's `_config.yml` file
 ```yml
 plugins:
   - jekyll-last-modified-at
+
+# Optional. The default date format, used if none is specified in the tag.
+date_format: '%d-%b-%y'
 ```
 
 ## Usage

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -3,12 +3,13 @@
 module Jekyll
   module LastModifiedAt
     class Determinator
-      attr_reader :site_source, :page_path, :opts
+      attr_reader :site_source, :page_path
+      attr_accessor :format
 
-      def initialize(site_source, page_path, opts = {})
+      def initialize(site_source, page_path, format = nil)
         @site_source = site_source
         @page_path   = page_path
-        @opts        = opts
+        @format      = format || '%d-%b-%y'
       end
 
       def git
@@ -21,7 +22,7 @@ module Jekyll
       def formatted_last_modified_date
         return PATH_CACHE[page_path] unless PATH_CACHE[page_path].nil?
 
-        last_modified = last_modified_at_time.strftime(format)
+        last_modified = last_modified_at_time.strftime(@format)
         PATH_CACHE[page_path] = last_modified
         last_modified
       end
@@ -58,14 +59,6 @@ module Jekyll
 
       def to_liquid
         @to_liquid ||= last_modified_at_time
-      end
-
-      def format
-        opts['format'] ||= '%d-%b-%y'
-      end
-
-      def format=(new_format)
-        opts['format'] = new_format
       end
 
       private

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -5,7 +5,9 @@ module Jekyll
     module Hook
       def self.add_determinator_proc
         proc { |item|
-          item.data['last_modified_at'] = Determinator.new(item.site.source, item.path)
+          format = item.site.config['date_format']
+          item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
+                                                           format)
         }
       end
 

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -5,7 +5,7 @@ module Jekyll
     module Hook
       def self.add_determinator_proc
         proc { |item|
-          format = item.site.config['date_format']
+          format = item.site.config.dig('last-modified-at', 'date-format')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
                                                            format)
         }

--- a/lib/jekyll-last-modified-at/tag.rb
+++ b/lib/jekyll-last-modified-at/tag.rb
@@ -9,11 +9,11 @@ module Jekyll
       end
 
       def render(context)
-        site_source = context.registers[:site].source
+        site = context.registers[:site]
+        format = @format || site.config['date_format']
         article_file = context.environments.first['page']['path']
-
-        Determinator.new(site_source, article_file,
-                         'format' => @format).formatted_last_modified_date
+        Determinator.new(site.source, article_file, format)
+                    .formatted_last_modified_date
       end
     end
   end

--- a/lib/jekyll-last-modified-at/tag.rb
+++ b/lib/jekyll-last-modified-at/tag.rb
@@ -10,7 +10,7 @@ module Jekyll
 
       def render(context)
         site = context.registers[:site]
-        format = @format || site.config['date_format']
+        format = @format || site.config.dig('last-modified-at', 'date-format')
         article_file = context.environments.first['page']['path']
         Determinator.new(site.source, article_file, format)
                     .formatted_last_modified_date

--- a/spec/plugins/last_modified_at_spec.rb
+++ b/spec/plugins/last_modified_at_spec.rb
@@ -39,7 +39,7 @@ describe 'Last Modified At Tag' do
     end
 
     it 'has last revised date' do
-      expect(@post.output).to match(Regexp.new("Article last updated on #{Time.new.strftime('%d-%b-%y')}"))
+      expect(@post.output).to match(Regexp.new("Article last updated on #{Time.new.utc.strftime('%d-%b-%y')}"))
     end
   end
 end


### PR DESCRIPTION
This small modifications adds configurable options. Namely, it allows to change the default format (with the default being the current one), and an option to set the timezome to UTC (disabled by default).

Setting the timezone to UTC is IMHO pretty important and useful if the website is not build on a local PC but on a site such as GitHub Actions or any other pipeline where the timezone may change between runs.