### PR TITLE
Fix block indentation

### DIFF
--- a/lib/jekyll-last-modified-at/executor.rb
+++ b/lib/jekyll-last-modified-at/executor.rb
@@ -25,10 +25,10 @@ module Jekyll
       ensure
         [r, w, e, eo].each do |io|
           begin
-                                   io.close
+            io.close
           rescue StandardError
             nil
-                                 end
+          end
         end
       end
     end

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -17,8 +17,8 @@ module Jekyll
           Dir.chdir(@site_source) do
             @top_level_directory = File.join(Executor.sh('git', 'rev-parse', '--show-toplevel'), '.git')
           end
-                                 rescue StandardError
-                                   ''
+        rescue StandardError
+          ''
         end
       end
 
@@ -29,8 +29,8 @@ module Jekyll
           Dir.chdir(@site_source) do
             Executor.sh('git', 'rev-parse', '--is-inside-work-tree').eql? 'true'
           end
-                       rescue StandardError
-                         false
+        rescue StandardError
+          false
         end
       end
     end


### PR DESCRIPTION
This pull request updates how a handful of blocks are indented to line up with the indentation of the line that contains the starting `begin`.