### PR TITLE
Add support for files in Git submodules

### DIFF
--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -38,7 +38,7 @@ module Jekyll
           last_commit_date = Executor.sh(
             'git',
             '--git-dir',
-            git.top_level_directory,
+            git_dir_for_article,
             'log',
             '-n',
             '1',
@@ -63,6 +63,17 @@ module Jekyll
 
       private
 
+      def git_dir_for_article
+        submodule_git_dir_path || git.top_level_directory
+      end
+
+      def submodule_git_dir_path
+        article_parent_dir_path = Jekyll.sanitized_path(site_source, File.dirname(@page_path))
+        return nil unless git.dir_is_submodule?(article_parent_dir_path)
+
+        Jekyll.sanitized_path(site_source, File.dirname(@page_path) + '/.git')
+      end
+
       def absolute_path_to_article
         @absolute_path_to_article ||= Jekyll.sanitized_path(site_source, @page_path)
       end
@@ -72,7 +83,7 @@ module Jekyll
 
         @relative_path_from_git_dir ||= Pathname.new(absolute_path_to_article)
                                                 .relative_path_from(
-                                                  Pathname.new(File.dirname(git.top_level_directory))
+                                                  Pathname.new(File.dirname(git_dir_for_article))
                                                 ).to_s
       end
 

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -10,6 +10,15 @@ module Jekyll
         @is_git_repo = nil
       end
 
+      def dir_is_submodule?(directory)
+        Dir.chdir(directory) do
+          submodule_dir = Executor.sh('git', 'rev-parse', '--show-superproject-working-tree')
+          submodule_dir != ''
+        rescue StandardError
+          false
+        end
+      end
+
       def top_level_directory
         return nil unless git_repo?
 


### PR DESCRIPTION
This pull request adds support for files in Git submodules within a given project. Without this pull request, all files within a Git submodule report their "last modified" date as the timestamp of the commit that updated the submodule.

I've manually tested this locally against two Jekyll sites: one that doesn't use Git submodules, and one that does. Both behave correctly.

However, I'm struggling to find a good way to test this. @gjtorikian, I would appreciate a bit of help to test this out properly.