### PR TITLE
use PATH_CACHE consistently within determinator.rb

### DIFF
--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -20,17 +20,15 @@ module Jekyll
       end
 
       def formatted_last_modified_date
-        return PATH_CACHE[page_path] unless PATH_CACHE[page_path].nil?
-
-        last_modified = last_modified_at_time.strftime(@format)
-        PATH_CACHE[page_path] = last_modified
-        last_modified
+        last_modified_at_time.strftime(@format)
       end
 
       def last_modified_at_time
         raise Errno::ENOENT, "#{absolute_path_to_article} does not exist!" unless File.exist? absolute_path_to_article
+        return PATH_CACHE[page_path] unless PATH_CACHE[page_path].nil?
 
-        Time.at(last_modified_at_unix.to_i)
+        PATH_CACHE[page_path] = Time.at(last_modified_at_unix.to_i)
+        PATH_CACHE[page_path]
       end
 
       def last_modified_at_unix

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -6,7 +6,7 @@ module Jekyll
       def self.add_determinator_proc
         proc { |item|
           format = item.site.config.dig('last-modified-at', 'date-format')
-          item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
+          item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format)
         }
       end


### PR DESCRIPTION
Previously, `PATH_CACHE` was only used by `formatted_last_modified_date` and
not by `last_modified_at`. This resulted in last modified time being
re-determined when using:

{{ page.last_modified_at }}

but not when using:

{% last_modified_at %}

This change aligns the behavior and, as a by product, improves site reset
render performance for users of `page.last_modified_at`. Initial site
generation render performance is unaffected. The tradeoff is that data can get
stale in the cache, and repo information is not reread on reset.

More information available in #85

**I did not test extensively** but did verify that `bundle exec rake spec` passed and `bundle exec rake rubocop` did not introduce any new issues.