### PR TITLE
Ignore commits starting with "META" in commit message

### DIFF
--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -40,6 +40,8 @@ module Jekyll
             '--git-dir',
             git.top_level_directory,
             'log',
+            '--grep=^META',
+            '--invert-grep',
             '-n',
             '1',
             '--format="%ct"',

--- a/lib/jekyll-last-modified-at/version.rb
+++ b/lib/jekyll-last-modified-at/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module LastModifiedAt
-    VERSION = '1.3.0'
+    VERSION = '1.3.1-PEM1'
   end
 end


### PR DESCRIPTION
For my blog, I want to ignore changes to the Jekyll front matter—changing tags and the like.  This commit adds `--grep=^META --invert-grep` to the Git `log` command.  Any commit messages starting with "META" are ignored for the purposes of displaying the last-modified date.

I'm unsure if the caching proposals in https://github.com/gjtorikian/jekyll-last-modified-at/pull/86 and https://github.com/gjtorikian/jekyll-last-modified-at/pull/87 by @klandergren are incompatible with this change or if @trickv's option of AuthorDate (https://github.com/gjtorikian/jekyll-last-modified-at/pull/53) is a better approach.