### PR TITLE
Add option to set `page.date` automatically with the file creation date

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ last-modified-at:
     date-format: '%d-%b-%y'
 ```
 
+For sites with lots of documents using `last_modified_at`, there may be render
+performance improvement via:
+
+```yml
+plugins:
+  - jekyll-last-modified-at
+
+last-modified-at:
+    use-git-cache: true
+```
+
+If `use-git-cache` is `false` (the default), every committed file using
+`last_modified_at` will generate a separate spawned process to check the git log
+for time data. So if you have 10 documents, this will result in 10 spawned calls.
+
+If `use-git-cache` is `true`, a single spawned process is generated that reads
+the entire git log history and caches the time data. This cache is then read
+from during the rest of the site generation process. So if you have 10 (or 1000)
+documents, this will result in 1 spawned call. The cache is flushed on site
+reset, allowing for a long-lived server to correctly reflect `last_modified_at`
+of files modified and committed while it has been running.
+
+Note: there may be performance issues for repositories with very large
+histories, in which case the default behavior is likely preferred.
+
 ## Usage
 
 There are a few ways to use this gem.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ plugins:
 last-modified-at:
     date-format: '%d-%b-%y'
 ```
-
-You can also set `set-page-date: true` to have the plugin determine the datetime the file was first commited and use that to automatically set the post's default `date`.  This will use the file's `ctime` if there's no git information.
-
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:
 
@@ -84,3 +81,18 @@ To format such a time, you'll need to rely on Liquid's `date` filter:
 ```
 
 (It's generally [more performant to use the `page.last_modified_at` version](https://github.com/gjtorikian/jekyll-last-modified-at/issues/24#issuecomment-55431108) of this plugin.)
+
+## `page.date`
+
+Additionally, you can have this plugin automatically set a default `date` value on every page based on when the file was **first** commited in git. To enable this, set `set-page-date` to `true` in your config yaml:
+
+ ```yml
+plugins:
+  - jekyll-last-modified-at
+
+last-modified-at:
+    set-page-date: true
+```
+
+If a post's date is already set via [the filename](https://jekyllrb.com/docs/posts/#creating-posts) or a page's date is set in its [frontmatter](https://jekyllrb.com/docs/variables/#page-variables), those values will override the value provided by this plugin. If a git date isn't available, `ctime` is used.
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ last-modified-at:
     date-format: '%d-%b-%y'
 ```
 
+You can also set `override-date: true` to have "last-modified-at" determine the datetime the file was first commited and use that to automatically set the post's `date` field.  Will use `ctime` if there's no git information.
+
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ last-modified-at:
     date-format: '%d-%b-%y'
 ```
 
-You can also set `override-date: true` to have "last-modified-at" determine the datetime the file was first commited and use that to automatically set the post's `date` field.  Will use `ctime` if there's no git information.
+You can also set `set-page-date: true` to have the plugin determine the datetime the file was first commited and use that to automatically set the post's default `date`.  This will use the file's `ctime` if there's no git information.
 
 For sites with lots of documents using `last_modified_at`, there may be render
 performance improvement via:

--- a/lib/jekyll-last-modified-at.rb
+++ b/lib/jekyll-last-modified-at.rb
@@ -9,8 +9,5 @@ module Jekyll
     autoload :Executor, 'jekyll-last-modified-at/executor'
     autoload :Determinator, 'jekyll-last-modified-at/determinator'
     autoload :Git, 'jekyll-last-modified-at/git'
-
-    PATH_CACHE = {} # rubocop:disable Style/MutableConstant
-    REPO_CACHE = {} # rubocop:disable Style/MutableConstant
   end
 end

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -3,49 +3,47 @@
 module Jekyll
   module LastModifiedAt
     class Determinator
-      attr_reader :site_source, :page_path
+      @repo_cache = {}
+      @path_cache = {}
+      class << self
+        # attr_accessor so we can flush externally
+        attr_accessor :repo_cache
+        attr_accessor :path_cache
+      end
+
+      attr_reader :site_source, :page_path, :use_git_cache
       attr_accessor :format
 
-      def initialize(site_source, page_path, format = nil)
-        @site_source = site_source
-        @page_path   = page_path
-        @format      = format || '%d-%b-%y'
+      def initialize(site_source, page_path, format = nil, use_git_cache = false) # rubocop:disable Style/OptionalBooleanParameter
+        @site_source   = site_source
+        @page_path     = page_path
+        @format        = format || '%d-%b-%y'
+        @use_git_cache = use_git_cache
       end
 
       def git
-        return REPO_CACHE[site_source] unless REPO_CACHE[site_source].nil?
+        return self.class.repo_cache[site_source] unless self.class.repo_cache[site_source].nil?
 
-        REPO_CACHE[site_source] = Git.new(site_source)
-        REPO_CACHE[site_source]
+        self.class.repo_cache[site_source] = Git.new(site_source)
+        self.class.repo_cache[site_source]
       end
 
       def formatted_last_modified_date
-        return PATH_CACHE[page_path] unless PATH_CACHE[page_path].nil?
-
-        last_modified = last_modified_at_time.strftime(@format)
-        PATH_CACHE[page_path] = last_modified
-        last_modified
+        last_modified_at_time.strftime(@format)
       end
 
       def last_modified_at_time
+        return self.class.path_cache[page_path] unless self.class.path_cache[page_path].nil?
+
         raise Errno::ENOENT, "#{absolute_path_to_article} does not exist!" unless File.exist? absolute_path_to_article
 
-        Time.at(last_modified_at_unix.to_i)
+        self.class.path_cache[page_path] = Time.at(last_modified_at_unix.to_i)
+        self.class.path_cache[page_path]
       end
 
       def last_modified_at_unix
         if git.git_repo?
-          last_commit_date = Executor.sh(
-            'git',
-            '--git-dir',
-            git.top_level_directory,
-            'log',
-            '-n',
-            '1',
-            '--format="%ct"',
-            '--',
-            relative_path_from_git_dir
-          )[/\d+/]
+          last_commit_date = git.last_commit_date(relative_path_from_git_dir, use_git_cache)
           # last_commit_date can be nil iff the file was not committed.
           last_commit_date.nil? || last_commit_date.empty? ? mtime(absolute_path_to_article) : last_commit_date
         else

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -28,7 +28,6 @@ module Jekyll
         return self.class.repo_cache[site_source] unless self.class.repo_cache[site_source].nil?
 
         self.class.repo_cache[site_source] = Git.new(site_source)
-        self.class.repo_cache[site_source]
       end
 
       def formatted_last_modified_date
@@ -45,7 +44,6 @@ module Jekyll
         raise Errno::ENOENT, "#{absolute_path_to_article} does not exist!" unless File.exist? absolute_path_to_article
 
         self.class.first_mod_cache[page_path] = Time.at(first_modified_at_unix.to_i)
-        self.class.first_mod_cache[page_path]
       end
 
       def first_modified_at_unix

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -8,6 +8,7 @@ module Jekyll
       def initialize(site_source)
         @site_source = site_source
         @is_git_repo = nil
+        @lcd_cache = {}
       end
 
       def top_level_directory
@@ -31,6 +32,66 @@ module Jekyll
           end
                        rescue StandardError
                          false
+        end
+      end
+
+      def last_commit_date(path, use_git_cache = false) # rubocop:disable Style/OptionalBooleanParameter
+        if use_git_cache
+          build_lcd_cache if @lcd_cache.empty?
+          @lcd_cache[path]
+        else
+          Executor.sh(
+            'git',
+            '--git-dir',
+            top_level_directory,
+            'log',
+            '-n',
+            '1',
+            '--format="%ct"',
+            '--',
+            path
+          )[/\d+/]
+        end
+      end
+
+      private
+
+      # generates hash of `path => unix time stamp (string)`
+      def build_lcd_cache
+        # example output:
+        #
+        # %jekyll-last-modified-at:1621042992
+        #
+        # Dockerfile.production
+        # %jekyll-last-modified-at:1621041929
+        #
+        # assets/css/style.52513a5600efd4015668ccb9b702256e.css
+        # assets/css/style.52513a5600efd4015668ccb9b702256e.css.gz
+        lines = Executor.sh(
+          'git',
+          '--git-dir',
+          top_level_directory,
+          'log',
+          '--name-only',
+          '--date=unix',
+          '--pretty=%%jekyll-last-modified-at:%ct'
+        )
+
+        lcd = nil
+        lines.split("\n").each do |line|
+          next if line.empty?
+
+          if line.start_with?('%jekyll-last-modified-at:')
+            # new record
+            lcd = line.split(':')[1]
+            next
+          end
+
+          # we already have it
+          next if @lcd_cache[line]
+
+          # we don't have it
+          @lcd_cache[line] = lcd
         end
       end
     end

--- a/lib/jekyll-last-modified-at/git.rb
+++ b/lib/jekyll-last-modified-at/git.rb
@@ -65,6 +65,8 @@ module Jekyll
             '--git-dir',
             top_level_directory,
             'log',
+            '--follow',
+            '--diff-filter=A',
             '--format="%ct"',
             '--',
             path

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -6,9 +6,19 @@ module Jekyll
       def self.add_determinator_proc
         proc { |item|
           format = item.site.config.dig('last-modified-at', 'date-format')
+          use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
-                                                           format)
+                                                           format, use_git_cache)
         }
+      end
+
+      Jekyll::Hooks.register :site, :after_reset do |site|
+        use_git_cache = site.config.dig('last-modified-at', 'use-git-cache')
+        if use_git_cache
+          # flush the caches so we can detect commits while server is running
+          Determinator.repo_cache = {}
+          Determinator.path_cache = {}
+        end
       end
 
       Jekyll::Hooks.register :posts, :post_init, &Hook.add_determinator_proc

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -7,7 +7,7 @@ module Jekyll
         proc { |item|
           format = item.site.config.dig('last-modified-at', 'date-format')
           use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
-          item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
+          item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
         }
       end

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -9,7 +9,7 @@ module Jekyll
           use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
-          if item.site.config.dig('last-modified-at', 'override-date')
+          if item.site.config.dig('last-modified-at', 'set-page-date')
             # The "date" field will be converted to a string first by Jekyll and it must be
             # in the format given below: https://jekyllrb.com/docs/variables/#page-variables
             item.data['date'] = Determinator.new(item.site.source, item.relative_path,

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -9,16 +9,13 @@ module Jekyll
           use_git_cache = item.site.config.dig('last-modified-at', 'use-git-cache')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.relative_path,
                                                            format, use_git_cache)
+          if item.site.config.dig('last-modified-at', 'override-date')
+            # The "date" field will be converted to a string first by Jekyll and it must be
+            # in the format given below: https://jekyllrb.com/docs/variables/#page-variables
+            item.data['date'] = Determinator.new(item.site.source, item.relative_path,
+                                                 '%Y-%m-%d %H:%M:%S %z', use_git_cache, true)
+          end
         }
-      end
-
-      Jekyll::Hooks.register :site, :after_reset do |site|
-        use_git_cache = site.config.dig('last-modified-at', 'use-git-cache')
-        if use_git_cache
-          # flush the caches so we can detect commits while server is running
-          Determinator.repo_cache = {}
-          Determinator.path_cache = {}
-        end
       end
 
       Jekyll::Hooks.register :posts, :post_init, &Hook.add_determinator_proc


### PR DESCRIPTION
This PR builds on @klandergren's `git-cache` PR: https://github.com/gjtorikian/jekyll-last-modified-at/pull/87

It adds support for the "first posted at" variable suggested in https://github.com/gjtorikian/jekyll-last-modified-at/issues/90 but places that variable instead in the `page.date` slot so that it will work out-of-the-box with other plugins (such as `jekyll-feed`) which rely on the `page.date` variable.