### PR TITLE
Add option to specify extra git options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ Add the following to your site's `_config.yml` file
 plugins:
   - jekyll-last-modified-at
 
-# Optional. The default date format, used if none is specified in the tag.
+# Optional
 last-modified-at:
+    # Optional. The default date format, used if none is specified in the tag.
     date-format: '%d-%b-%y'
+    # Optional. The extra options passed to git to obtain the latest commit.
+    git-options:
+      - --grep
+      - \[no-update\].*
+      - --invert-grep
 ```
 
 ## Usage

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -6,10 +6,11 @@ module Jekyll
       attr_reader :site_source, :page_path
       attr_accessor :format
 
-      def initialize(site_source, page_path, format = nil)
+      def initialize(site_source, page_path, format = nil, git_options = [])
         @site_source = site_source
         @page_path   = page_path
         @format      = format || '%d-%b-%y'
+        @git_options = git_options
       end
 
       def git
@@ -40,6 +41,7 @@ module Jekyll
             '--git-dir',
             git.top_level_directory,
             'log',
+            *@git_options,
             '-n',
             '1',
             '--format="%ct"',

--- a/lib/jekyll-last-modified-at/determinator.rb
+++ b/lib/jekyll-last-modified-at/determinator.rb
@@ -4,7 +4,7 @@ module Jekyll
   module LastModifiedAt
     class Determinator
       attr_reader :site_source, :page_path
-      attr_accessor :format
+      attr_accessor :format, :git_options
 
       def initialize(site_source, page_path, format = nil, git_options = [])
         @site_source = site_source

--- a/lib/jekyll-last-modified-at/hook.rb
+++ b/lib/jekyll-last-modified-at/hook.rb
@@ -6,8 +6,9 @@ module Jekyll
       def self.add_determinator_proc
         proc { |item|
           format = item.site.config.dig('last-modified-at', 'date-format')
+          git_options = item.site.config.dig('last-modified-at', 'git-options')
           item.data['last_modified_at'] = Determinator.new(item.site.source, item.path,
-                                                           format)
+                                                           format, git_options)
         }
       end
 

--- a/lib/jekyll-last-modified-at/tag.rb
+++ b/lib/jekyll-last-modified-at/tag.rb
@@ -11,8 +11,9 @@ module Jekyll
       def render(context)
         site = context.registers[:site]
         format = @format || site.config.dig('last-modified-at', 'date-format')
+        git_options = site.config.dig('last-modified-at', 'git-options')
         article_file = context.environments.first['page']['path']
-        Determinator.new(site.source, article_file, format)
+        Determinator.new(site.source, article_file, format, git_options)
                     .formatted_last_modified_date
       end
     end

--- a/spec/jekyll-last-modified-at/determinator_spec.rb
+++ b/spec/jekyll-last-modified-at/determinator_spec.rb
@@ -76,4 +76,13 @@ describe(Jekyll::LastModifiedAt::Determinator) do
       expect(subject.format).to eql('%Y-%m-%d')
     end
   end
+
+  context 'with extra git commands set' do
+    let(:page_path)   { @fixtures_path.join('file.txt') }
+    let(:mod_time)    { Time.new(2014, 7, 19, 23, 24, 33, '-04:00') }
+    before(:each) { subject.git_options = ['--grep', 'New.*'] }
+    it 'grep the commit message' do
+      expect(subject.last_modified_at_time.to_i).to eql(mod_time.to_i)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds configurable option(`git-options`) which allows users to specify extra git options used in retrieving the latest commit.

This is useful for filtering the commits by the commit message.
```yml
last-modified-at:
  git-options:
    - --grep
    - \[no-update\].*
    - --invert-grep
```